### PR TITLE
adding css styles to display photos.

### DIFF
--- a/wp-content/plugins/user-submitted-posts/library/shortcode-misc.php
+++ b/wp-content/plugins/user-submitted-posts/library/shortcode-misc.php
@@ -237,13 +237,13 @@ function usp_gallery($attr, $content = null) {
             $gallery = $gallery ? '<div class="usp-image-gallery">'
                 . $gallery
                 . '</div>'
-                . 'The original file name is <br>'
-                . $originalFileName
+                . '<span class="usp-title-label">The original file name: </span>'
+                . '<span class="usp-title-text">' . esc_html($originalFileName) . '</span>'
                 . '<br>'
-                . 'The original size is <br>'
-                . $filesize_var_MB
-                . ' MB<br>'
-                . 'Title:   ' . $item->post_title
+                . '<span class="usp-title-label">The original size: </span>'
+                . '<span class="usp-title-text">' . esc_html($filesize_var_MB) . ' MB<br>' . '</span>'
+                . '<span class="usp-title-label">Title:</span> '
+                . '<span class="usp-title-text">' . esc_html($item->post_title) . '</span>'
                 . '<br>'
                 . '<input type="button" name="'
                 . $item->ID


### PR DESCRIPTION
Remember need to add the styles under Wordpress UI > "Appearance" > "Customize" > "Additional Css styles"

.usp-title-label {
    font-weight: 700;
    color: #eaf1e9; /* Charcoal gray */
    text-transform: uppercase;
    font-size: 1.0rem;
    letter-spacing: 0.5px;
}

/* Style for the actual dynamic post title */
.usp-title-text {
    font-weight: 600;
    color: #32CD32;
    font-size: 1.1rem;
    font-family: inherit;
}